### PR TITLE
Drag blocks out of help screens

### DIFF
--- a/help/xml/reportFindFirst.xml
+++ b/help/xml/reportFindFirst.xml
@@ -103,7 +103,7 @@
                     </block>
                 </script>
                 <bubbles>
-                    <l />
+                    <text id="" />
                 </bubbles>
             </diagram>
             <diagram>

--- a/help/xml/reportFindFirst.xml
+++ b/help/xml/reportFindFirst.xml
@@ -103,7 +103,7 @@
                     </block>
                 </script>
                 <bubbles>
-                    <bool>false</bool>
+                    <l />
                 </bubbles>
             </diagram>
             <diagram>
@@ -137,7 +137,7 @@
             <p id="reportFindFirst.p.2">
                 <text font="Courier" id="reportFindFirst.p.2.Find first" />
                 <text font="Courier" id="reportFindFirst.p.2.Keep" />
-                </p>
+            </p>
             <p id="reportFindFirst.p.3">
                 <text font="Courier" id="reportFindFirst.p.3.Find first" />
                 <script>
@@ -153,7 +153,7 @@
                     </block>
                 </script>
                 <text font="Courier" id="reportFindFirst.p.3.find first" />
-                </p>
+            </p>
         </column>
     </box>
 </help-screen>

--- a/help/xml/reportFindFirst.xml
+++ b/help/xml/reportFindFirst.xml
@@ -103,7 +103,7 @@
                     </block>
                 </script>
                 <bubbles>
-                    <text id="" />
+                    <text id=" " />
                 </bubbles>
             </diagram>
             <diagram>

--- a/locale/help-en.js
+++ b/locale/help-en.js
@@ -1363,13 +1363,13 @@ SnapTranslator.dict.en.help_strings = {
     'reportFindFirst.p.2.Keep':
         'Keep',
     'reportFindFirst.p.2':
-        '{reportFindFirst.p.2.Find first} reports False if no item in the list matches the predicate.\n( {reportFindFirst.p.2.Keep} reports the empty list in that situation.)',
+        '{reportFindFirst.p.2.Find first} reports nothing if no item in the list matches the predicate.\n( {reportFindFirst.p.2.Keep} reports the empty list in that situation.)',
     'reportFindFirst.p.3.Find first':
         'Find first',
     'reportFindFirst.p.3.find first':
         'find first',
     'reportFindFirst.p.3':
-        '{reportFindFirst.p.3.Find first} means the same as {2} but {reportFindFirst.p.3.find first} is faster if a match is found because it doesn\'t search the rest of the list.',
+        '{reportFindFirst.p.3.Find first} is almost the same as {2} but {reportFindFirst.p.3.find first} is faster if a match is found because it doesn\'t search the rest of the list.',
 
     // reportGet
     'reportGet.header':

--- a/src/help.js
+++ b/src/help.js
@@ -1218,7 +1218,7 @@ ScriptDiagramMorph.prototype.init = function (
 };
 
 ScriptDiagramMorph.prototype.selectForEdit = function () {
-    return this.script;
+    return this.fullCopy().script;
 };
 
 ScriptDiagramMorph.prototype.populateDiagram = function () {

--- a/src/help.js
+++ b/src/help.js
@@ -1217,7 +1217,7 @@ ScriptDiagramMorph.prototype.init = function (
     this.populateDiagram();
 };
 
-ScriptDiagramMorph.prototype.reactToTemplateCopy = function () {
+ScriptDiagramMorph.prototype.selectForEdit = function () {
     return this.script;
 };
 

--- a/src/help.js
+++ b/src/help.js
@@ -1210,8 +1210,8 @@ ScriptDiagramMorph.prototype.init = function (
     // initialize inherited properties:
     ScriptDiagramMorph.uber.init.call(this);
 
-    this.isDraggable = false;
-    this.isTemplate = true;
+    this.isDraggable = true;
+    this.isTemplate = false;
 
     this.acceptsDrops = false;
     this.populateDiagram();

--- a/src/help.js
+++ b/src/help.js
@@ -1218,7 +1218,7 @@ ScriptDiagramMorph.prototype.init = function (
 };
 
 ScriptDiagramMorph.prototype.selectForEdit = function () {
-    return this.fullCopy().script;
+    return this.script.fullCopy();
 };
 
 ScriptDiagramMorph.prototype.populateDiagram = function () {

--- a/src/help.js
+++ b/src/help.js
@@ -1218,7 +1218,9 @@ ScriptDiagramMorph.prototype.init = function (
 };
 
 ScriptDiagramMorph.prototype.selectForEdit = function () {
-    return this.script.fullCopy();
+    var newscript = this.script.fullCopy();
+    newscript.setPosition(this.position());
+    return newscript;
 };
 
 ScriptDiagramMorph.prototype.populateDiagram = function () {

--- a/src/help.js
+++ b/src/help.js
@@ -1210,8 +1210,15 @@ ScriptDiagramMorph.prototype.init = function (
     // initialize inherited properties:
     ScriptDiagramMorph.uber.init.call(this);
 
+    this.isDraggable = false;
+    this.isTemplate = true;
+
     this.acceptsDrops = false;
     this.populateDiagram();
+};
+
+ScriptDiagramMorph.prototype.reactToTemplateCopy = function () {
+    return this.script;
 };
 
 ScriptDiagramMorph.prototype.populateDiagram = function () {

--- a/src/help.js
+++ b/src/help.js
@@ -1218,8 +1218,9 @@ ScriptDiagramMorph.prototype.init = function (
 };
 
 ScriptDiagramMorph.prototype.selectForEdit = function () {
-    var newscript = this.script.fullCopy();
-    newscript.setPosition(this.position());
+    var newscript = this.script.fullCopy(),
+        hand = this.parentThatIsA(WorldMorph).hand;
+    newscript.setPosition(this.script.position());
     return newscript;
 };
 

--- a/src/help.js
+++ b/src/help.js
@@ -1218,9 +1218,8 @@ ScriptDiagramMorph.prototype.init = function (
 };
 
 ScriptDiagramMorph.prototype.selectForEdit = function () {
-    var newscript = this.script.fullCopy(),
-        hand = this.parentThatIsA(WorldMorph).hand;
-    newscript.setPosition(this.script.position());
+    var newscript = this.script.fullCopy();
+    newscript.setPosition(this.position());
     return newscript;
 };
 


### PR DESCRIPTION
Duplicate of [my other one](https://github.com/djsrv/snap/pull/1) that closed because I renamed my branch.

Test it here:
https://warpedwartwars.github.io/Snap/snap.html

- [ ] fix blocks getting put in the wrong spot
  - [x] fix blocks going to 0@0
  - [ ] fix blocks going to top-left of ScriptDiagramMorph when the script isn't at the top-left
- [ ] fix blocks dragged out of help screens into palette erroring
  - apparently hand.grabOrigin is null
