### PR TITLE
Make help screen's blocks draggable

### DIFF
--- a/src/help.js
+++ b/src/help.js
@@ -1210,8 +1210,17 @@ ScriptDiagramMorph.prototype.init = function (
     // initialize inherited properties:
     ScriptDiagramMorph.uber.init.call(this);
 
+    this.isDraggable = true;
+    this.isTemplate = false;
+
     this.acceptsDrops = false;
     this.populateDiagram();
+};
+
+ScriptDiagramMorph.prototype.selectForEdit = function () {
+    var newscript = this.script.fullCopy();
+    newscript.setPosition(this.position());
+    return newscript;
 };
 
 ScriptDiagramMorph.prototype.populateDiagram = function () {


### PR DESCRIPTION
Duplicate of [my other one](https://github.com/djsrv/snap/pull/2) that closed because I reforked `jmoenig/Snap`.

- [ ] fix blocks getting put in the wrong spot
  - [x] fix blocks going to 0@0
  - [ ] fix blocks going to top-left of ScriptDiagramMorph when the script isn't at the top-left
- [ ] fix blocks dragged out of help screens into palette erroring
  - apparently hand.grabOrigin is null